### PR TITLE
fix for index file generation

### DIFF
--- a/src/main/scala/com/yurique/embedded/sbt/EmbeddedFilesPlugin.scala
+++ b/src/main/scala/com/yurique/embedded/sbt/EmbeddedFilesPlugin.scala
@@ -128,7 +128,7 @@ object EmbeddedFilesPlugin extends AutoPlugin {
           }
       }
       if (embedGenerateIndex.value) {
-        val generatedClasses = needToEmbed.flatMap { path =>
+        val generatedClasses = sourceMap.values.flatMap { path =>
           embedDirectories.value
             .flatMap(path.toFile.relativeTo)
             .headOption


### PR DESCRIPTION
If the `needToEmbed` is used to compute the index, then only files which have been added will be added to the index instead of all files. This means that if you are doing e.g. `~fastOptJS`, the index will go empty once you make a change somewhere else in your codebase. This is one potential fix.

BTW, thank you for all the work you are doing in the ScalaJS world. Super awesome stuff!
